### PR TITLE
Use faster string-operations for building node content

### DIFF
--- a/source/CsQuery.Tests/Core/Dom/DomText.cs
+++ b/source/CsQuery.Tests/Core/Dom/DomText.cs
@@ -25,7 +25,7 @@ namespace CsQuery.Tests.Core.Dom
         {
             var textNode = Objects.CreateTextNode("");
             Assert.AreEqual("",textNode.NodeValue);
-            textNode.NodeValue = null;
+            textNode = Objects.CreateTextNode(null);
             Assert.AreEqual("", textNode.NodeValue);
 
         }

--- a/source/CsQuery/CsQuery.csproj
+++ b/source/CsQuery/CsQuery.csproj
@@ -404,6 +404,7 @@
     <Compile Include="Engine\SelectorParser.cs" />
     <Compile Include="ExtensionMethods\Forms.cs" />
     <Compile Include="Utility\FastActivator.cs" />
+    <Compile Include="Utility\FastString.cs" />
     <Compile Include="Utility\SelectorCache.cs" />
     <Compile Include="Utility\Types.cs" />
     <Compile Include="Web\enumRequestState.cs" />

--- a/source/CsQuery/Dom/IDomNode.cs
+++ b/source/CsQuery/Dom/IDomNode.cs
@@ -30,7 +30,7 @@ namespace CsQuery
         string NodeName { get; }
 
         /// <summary>
-        /// Gets or sets the value of this node.
+        /// Gets the value of this node.
         /// </summary>
         ///
         /// <remarks>
@@ -42,7 +42,13 @@ namespace CsQuery
         /// https://developer.mozilla.org/en/DOM/Node.nodeValue
         /// </url>
 
-        string NodeValue { get; set; }
+        string NodeValue { get; }
+
+        /// <summary>
+        /// Append to the value of this node. The text to append must be non-null.
+        /// </summary>
+
+        void AppendNodeValue(string text);
 
         /// <summary>
         /// Gets a value indicating whether this object has any children. For node types that cannot have

--- a/source/CsQuery/Dom/Implementation/DomCData.cs
+++ b/source/CsQuery/Dom/Implementation/DomCData.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using CsQuery.Utility;
 
 namespace CsQuery.Implementation
 {
@@ -19,7 +20,7 @@ namespace CsQuery.Implementation
         public DomCData()
             : base()
         {
-            _NonAttributeData = "";
+            _NonAttributeData = new FastString("");
         }
 
         /// <summary>
@@ -33,10 +34,10 @@ namespace CsQuery.Implementation
         public DomCData(string value)
             : base()
         {
-            NodeValue = value;
+            _NonAttributeData = new FastString(value);
         }
 
-        private string _NonAttributeData;
+        private FastString _NonAttributeData;
 
         /// <summary>
         /// Gets or sets the node value. For CDATA nodes, this is the content.
@@ -46,13 +47,15 @@ namespace CsQuery.Implementation
         {
             get
             {
-                return NonAttributeData;
-            }
-            set
-            {
-                NonAttributeData = value;
+                return _NonAttributeData.Value;
             }
         }
+
+        public override void AppendNodeValue(string text)
+        {
+            _NonAttributeData.AppendValue(text);
+        }
+
 
         /// <summary>
         /// Gets the type of the node. For CDATA nodes, this is NodeType.CDATA_SECTION_NODE.
@@ -75,11 +78,11 @@ namespace CsQuery.Implementation
         {
             get
             {
-                return _NonAttributeData;
+                return _NonAttributeData.Value;
             }
             set
             {
-                _NonAttributeData = value ?? "";
+                _NonAttributeData = new FastString(value ?? "");
             }
         }
 

--- a/source/CsQuery/Dom/Implementation/DomComment.cs
+++ b/source/CsQuery/Dom/Implementation/DomComment.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using CsQuery.Utility;
 
 namespace CsQuery.Implementation
 {
@@ -20,7 +21,7 @@ namespace CsQuery.Implementation
         public DomComment()
             : base()
         {
-            _NonAttributeData = "";
+            _NonAttributeData = new FastString("");
         }
 
         /// <summary>
@@ -33,7 +34,7 @@ namespace CsQuery.Implementation
 
         public DomComment(string text): base()
         {
-            NodeValue = text;
+            _NonAttributeData = new FastString(text);
         }
 
 
@@ -41,7 +42,7 @@ namespace CsQuery.Implementation
 
         #region private properties
 
-        private string _NonAttributeData;
+        private FastString _NonAttributeData;
 
         #endregion
 
@@ -130,11 +131,11 @@ namespace CsQuery.Implementation
         {
             get
             {
-                return _NonAttributeData;
+                return _NonAttributeData.Value;
             }
             set
             {
-                _NonAttributeData = value ?? "";
+                _NonAttributeData = new FastString(value ?? "");
             }
         }
 
@@ -142,17 +143,17 @@ namespace CsQuery.Implementation
         /// <summary>
         /// Gets or sets the node value. For CDATA nodes, this is the content.
         /// </summary>
-
         public override string NodeValue
         {
             get
             {
                 return NonAttributeData;
             }
-            set
-            {
-                NonAttributeData = value;
-            }
+        }
+
+        public override void AppendNodeValue(string text)
+        {
+            NonAttributeData = text;
         }
 
         /// <summary>

--- a/source/CsQuery/Dom/Implementation/DomObject.cs
+++ b/source/CsQuery/Dom/Implementation/DomObject.cs
@@ -599,10 +599,11 @@ namespace CsQuery.Implementation
             {
                 return null;
             }
-            set
-            {
-                throw new InvalidOperationException("You can't set NodeValue for this node type.");
-            }
+        }
+
+        public virtual void AppendNodeValue(string text)
+        {
+            throw new InvalidOperationException("You can't set NodeValue for this node type.");
         }
 
         /// <summary>

--- a/source/CsQuery/Dom/Implementation/DomText.cs
+++ b/source/CsQuery/Dom/Implementation/DomText.cs
@@ -6,6 +6,7 @@ using System.Web;
 using System.IO;
 using CsQuery.HtmlParser;
 using CsQuery.Output;
+using CsQuery.Utility;
 
 namespace CsQuery.Implementation
 {
@@ -35,7 +36,7 @@ namespace CsQuery.Implementation
         public DomText(string nodeValue)
             : base()
         {
-            NodeValue = nodeValue;
+            _NodeValue = new FastString(nodeValue);
         }
 
 
@@ -43,7 +44,7 @@ namespace CsQuery.Implementation
         /// The inner node value; the text.
         /// </summary>
 
-        protected string _NodeValue;
+        protected readonly FastString _NodeValue;
        
 
         /// <summary>
@@ -77,12 +78,13 @@ namespace CsQuery.Implementation
         {
             get
             {
-                return _NodeValue ?? "";
+                return _NodeValue.Value ?? "";
             }
-            set
-            {
-                _NodeValue=value;
-            }
+        }
+
+        public override void AppendNodeValue(string text)
+        {
+            _NodeValue.AppendValue(text);
         }
 
         /// <summary>

--- a/source/CsQuery/HtmlParser/CsQueryTreeBuilder.cs
+++ b/source/CsQuery/HtmlParser/CsQueryTreeBuilder.cs
@@ -90,8 +90,7 @@ namespace CsQuery.HtmlParser
             IDomText lastChild = parent.LastChild as IDomText;
             if (lastChild != null)
             {
-                lastChild.NodeValue += text;
-                
+                lastChild.AppendNodeValue(text);
             } else {
                 lastChild = Document.CreateTextNode(text);
                 parent.AppendChildUnsafe(lastChild);
@@ -374,7 +373,7 @@ namespace CsQuery.HtmlParser
                         && previousSibling.NodeType == NodeType.TEXT_NODE)
                 {
                     IDomText lastAsText = (IDomText)previousSibling;
-                    lastAsText.NodeValue += text;
+                    lastAsText.AppendNodeValue(text);
                     return;
                 }
                 parent.InsertBefore(Document.CreateTextNode(text), table);
@@ -385,7 +384,7 @@ namespace CsQuery.HtmlParser
             IDomText lastChild = stackParent.LastChild as IDomText;
             if (lastChild != null)
             {
-                lastChild.NodeValue += text;
+                lastChild.AppendNodeValue(text);
                 return;
             }
             else

--- a/source/CsQuery/Properties/AssemblyInfo.cs
+++ b/source/CsQuery/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.3.5.200")]
+[assembly: AssemblyVersion("1.3.6.0")]
 //[assembly: AssemblyFileVersion("1.3.3")]
 

--- a/source/CsQuery/Utility/FastString.cs
+++ b/source/CsQuery/Utility/FastString.cs
@@ -1,0 +1,43 @@
+﻿using System.Text;
+
+namespace CsQuery.Utility
+{
+    /// <summary>
+    /// A string-class optimized for appending lots of text. Can support null as the
+    /// initial string, which is used by some nodes (<seealso cref="IDomComment"/>).
+    /// </summary>
+    public class FastString
+    {
+        private readonly StringBuilder _stringBuilder = new StringBuilder();
+        private string _value;
+        private bool _isDirty;
+
+        public FastString(string value)
+        {
+            // Keep an initial null string as-is and only add/append non-null strings
+            if (value != null)
+            {
+                AppendValue(value);
+            }
+        }
+
+        public string Value
+        {
+            get
+            {
+                if (_isDirty)
+                {
+                    _value = _stringBuilder.ToString();
+                    _isDirty = false;
+                }
+                return _value;
+            }
+        }
+
+        public void AppendValue(string text)
+        {
+            _stringBuilder.Append(text);
+            _isDirty = true;
+        }
+    }
+}


### PR DESCRIPTION
Use faster string-operations for building node content.
The new code retains the exact same semantics as before, regarding null and empty strings.


